### PR TITLE
fix(containerfile): errant escape, npm param

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ FROM node:20-alpine
 LABEL org.label-schema.name="apidoc" \
     org.label-schema.description="apidoc container image" \
     org.label-schema.url="http://apidocjs.com/" \
-    org.label-schema.vcs-url="https://github.com/cdcabrera/apidoc" \
+    org.label-schema.vcs-url="https://github.com/cdcabrera/apidoc"
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
@@ -16,6 +16,6 @@ RUN mkdir -p /home/node/apidoc
 
 WORKDIR /home/node/apidoc
 
-RUN npm install --only=prod -g apidoc
+RUN npm install --omit=dev -g apidoc
 
 ENTRYPOINT ["apidoc"]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "eslint",
     "pre-commit": "npm run eslint && npm run test",
     "release": "changelog --non-cc --link-url https://github.com/cdcabrera/apidoc.git",
+    "container:build": "podman build -t apidoc/apidoc .",
     "serve:open": "xdg-open $PROTOCOL://$HOST:$PORT/ || open $PROTOCOL://$HOST:$PORT/",
     "serve:stop": "podman stop apidoc",
     "serve": "export PROTOCOL=http; export HOST=127.0.0.1; export PORT=8080; npm run build-example && podman run --rm --name apidoc -p $PORT:80 -v ./tmp/apidoc-output:/usr/share/nginx/html:ro -d nginx; npm run serve:open",


### PR DESCRIPTION
<!--
  IMPORTANT:
   - Read CONTRIBUTING.md
   - Base your PR/MR off the `dev` branch, and target the `dev` branch for merging.
-->

## What's included
<!-- List your changes/additions, or commits -->
- fix(containerfile): errant escape, npm param

### Notes
- containerfile had an extra line escape. bug added in the version 2.0.0 release
- migrates the naming convention... "Dockerfile" to "Containerfile"
<!-- Anything funky about your updates. Or issues that aren't resolved by this request, things of note? -->

## How to test
<!-- Are there directions to test/review? List the steps to confirm the issue is resolved -->

### Test check
1. update the NPM packages with `$ npm install`
1. `$ npm run container:build`
1. confirm the image for the container builds and then run against an input/output set of directories
   - `podman run --rm -v $(pwd):/home/node/apidoc apidoc/apidoc -o YOUR_OUTPUT_DIRECTORY -i YOUR_INPUT_DIRECTORY`

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->

ongoing